### PR TITLE
Add basic tests and static analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
-/composer.lock
-/docker-compose.yml
-/phpunit.xml
+composer.lock
+composer.phar
+docker-compose.yml
+tests/_output
 /vendor/
+/var/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,41 @@
 language: php
+sudo: false
+cache:
+    directories:
+        - $HOME/.composer/cache/files
 
-php:
-  - 7.2
-  - 7.3
-  - 7.4
+env:
+    global:
+        - SYMFONY_DEPRECATIONS_HELPER=weak
+        - PHPUNIT_FLAGS=""
+
+matrix:
+    fast_finish: true
+    include:
+        - php: 7.2
+          env: SYMFONY_REQUIRE=^4
+        - php: 7.2
+          env: SYMFONY_REQUIRE=^5
+        - php: 7.3
+          env: SYMFONY_REQUIRE=^4
+        - php: 7.3
+          env: SYMFONY_REQUIRE=^5
+        - php: 7.4
+          env: SYMFONY_REQUIRE=^4
+        - php: 7.4
+          env: SYMFONY_REQUIRE=^5
+        - php: 7.4
+
+before_install:
+    - composer self-update
 
 install:
+    - composer require symfony/flex --no-update
     - composer install --prefer-source
+    - vendor/bin/simple-phpunit install
 
 script:
-    - php vendor/bin/ecs check --set=psr12 --set=symfony ./src ./tests
+    - composer cs
+    - composer static
+    - composer validate --strict --no-check-lock
+    - vendor/bin/simple-phpunit $PHPUNIT_FLAGS

--- a/README.md
+++ b/README.md
@@ -146,3 +146,12 @@ headsnet_domain_events:
 Contributions are welcome. Please submit pull requests with one fix/feature per
 pull request.
 
+Composer scripts are configured for your convenience:
+
+```
+> composer test       # Run test suite
+> composer cs         # Run coding standards checks
+> composer cs-fix     # Fix coding standards violations
+> composer static     # Run static analysis with Phpstan
+```
+

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
   "scripts": {
     "cs": "vendor/bin/ecs check --ansi --config=ecs.php",
     "cs-fix": "vendor/bin/ecs check --ansi --config=ecs.php --fix",
-    "static": "vendor/bin/phpstan analyze src/ tests/ --ansi --level=8 -a vendor/autoload.php -a vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php",
+    "static": "vendor/bin/phpstan analyze --ansi",
     "test": "vendor/bin/simple-phpunit",
     "test-coverage": "vendor/bin/simple-phpunit --coverage-html tests/_output/coverage"
   }

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,13 @@
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/lock": "^4.4 || ^5.0",
     "symfony/serializer": "^4.4 || ^5.0",
-    "symfony/messenger": "^4.4 || ^5.0"
+    "symfony/messenger": "^4.4 || ^5.0",
+    "symfony/flex": "^1.9"
   },
   "require-dev": {
     "symfony/phpunit-bridge": "^5.0",
-    "symplify/easy-coding-standard": "^8.1"
+    "symplify/easy-coding-standard": "^8.1",
+    "nyholm/symfony-bundle-test": "^1.6"
   },
   "suggest": {
     "ext-amqp": "*"
@@ -33,9 +35,18 @@
   "autoload": {
     "psr-4": {
       "Headsnet\\DomainEventsBundle\\": "src/"
-    },
-    "exclude-from-classmap": [
-      "/Tests/"
-    ]
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Headsnet\\DomainEventsBundle\\": "tests/"
+    }
+  },
+  "scripts": {
+    "cs": "vendor/bin/ecs check --ansi --config=ecs.php",
+    "cs-fix": "vendor/bin/ecs check --ansi --config=ecs.php --fix",
+    "static": "vendor/bin/phpstan analyze src/ tests/ --ansi --level=8 -a vendor/autoload.php -a vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php",
+    "test": "vendor/bin/simple-phpunit",
+    "test-coverage": "vendor/bin/simple-phpunit --coverage-html tests/_output/coverage"
   }
 }

--- a/ecs.php
+++ b/ecs.php
@@ -1,0 +1,35 @@
+<?php
+/*
+ * This file is part of the Symfony HeadsnetDomainEventsBundle.
+ *
+ * (c) Headstrong Internet Services Ltd 2020
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use Symplify\EasyCodingStandard\Configuration\Option;
+use Symplify\EasyCodingStandard\ValueObject\Set\SetList;
+
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $parameters = $containerConfigurator->parameters();
+
+    $parameters->set(Option::PATHS, [
+        __DIR__ . '/src',
+        __DIR__ . '/tests',
+    ]);
+
+    $parameters->set(Option::SETS, [
+        SetList::CLEAN_CODE,
+        SetList::PSR_12,
+        SetList::SYMFONY,
+    ]);
+
+    $parameters->set(Option::EXCLUDE_PATHS, [
+        __DIR__ . '/src/Kernel.php',      // Created during the Travis build!
+        __DIR__ . '/tests/bootstrap.php', // Created during the Travis build!
+    ]);
+};

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,15 @@
+
+parameters:
+
+    level: 8
+
+    paths:
+        - src
+        - tests
+
+    excludes_analyse:
+        - tests/bootstrap.php
+
+    bootstrapFiles:
+        - vendor/autoload.php
+        - vendor/bin/.phpunit/phpunit-8.3-0/vendor/autoload.php # Include PHPUnit provided by symfony/phpunit-bridge

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~ This file is part of the Symfony HeadsnetDomainEventsBundle.
+  ~
+  ~ (c) Headstrong Internet Services Ltd 2020
+  ~
+  ~ For the full copyright and license information, please view the LICENSE
+  ~ file that was distributed with this source code.
+  -->
+
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.1/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="./vendor/autoload.php"
+         cacheResultFile="var/cache/.phpunit.results.cache"
+>
+    <php>
+        <ini name="error_reporting" value="-1" />
+        <ini name="intl.default_locale" value="en" />
+        <ini name="intl.error_level" value="0" />
+        <ini name="memory_limit" value="-1" />
+    </php>
+
+    <testsuites>
+        <testsuite name="Test suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,6 +21,8 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('headsnet_domain_events');
 
+        // @see https://github.com/phpstan/phpstan/issues/844
+        // @phpstan-ignore-next-line
         $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('message_bus')

--- a/src/DependencyInjection/HeadsnetDomainEventsExtension.php
+++ b/src/DependencyInjection/HeadsnetDomainEventsExtension.php
@@ -22,9 +22,12 @@ class HeadsnetDomainEventsExtension extends Extension implements PrependExtensio
 {
     private const DBAL_MICROSECONDS_TYPE = 'datetime_immutable_microseconds';
 
+    /**
+     * @param array<mixed> $configs
+     */
     public function load(array $configs, ContainerBuilder $container): void
     {
-        $loader = new XmlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
+        $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
 
         $configuration = new Configuration();
@@ -33,6 +36,9 @@ class HeadsnetDomainEventsExtension extends Extension implements PrependExtensio
         $this->useCustomMessageBusIfSpecified($config, $container);
     }
 
+    /**
+     * @param array<mixed> $config
+     */
     private function useCustomMessageBusIfSpecified(array $config, ContainerBuilder $container): void
     {
         if (isset($config['message_bus']['name'])) {
@@ -51,9 +57,9 @@ class HeadsnetDomainEventsExtension extends Extension implements PrependExtensio
         $config = [
             'dbal' => [
                 'types' => [
-                    self::DBAL_MICROSECONDS_TYPE => DateTimeImmutableMicrosecondsType::class
-                ]
-            ]
+                    self::DBAL_MICROSECONDS_TYPE => DateTimeImmutableMicrosecondsType::class,
+                ],
+            ],
         ];
 
         $container->prependExtensionConfig('doctrine', $config);

--- a/src/Doctrine/DBAL/Types/DateTimeImmutableMicrosecondsType.php
+++ b/src/Doctrine/DBAL/Types/DateTimeImmutableMicrosecondsType.php
@@ -27,7 +27,7 @@ class DateTimeImmutableMicrosecondsType extends VarDateTimeImmutableType
 
     public function getSQLDeclaration(array $fieldDeclaration, AbstractPlatform $platform): string
     {
-        if (isset($fieldDeclaration['version']) && $fieldDeclaration['version'] == true) {
+        if (isset($fieldDeclaration['version']) && true == $fieldDeclaration['version']) {
             return 'TIMESTAMP';
         }
 

--- a/src/Doctrine/EventSubscriber/PersistDomainEventSubscriber.php
+++ b/src/Doctrine/EventSubscriber/PersistDomainEventSubscriber.php
@@ -36,7 +36,7 @@ class PersistDomainEventSubscriber implements EventSubscriber
     public function getSubscribedEvents(): array
     {
         return [
-            'onFlush'
+            'onFlush',
         ];
     }
 

--- a/src/Domain/Model/DomainEvent.php
+++ b/src/Domain/Model/DomainEvent.php
@@ -29,7 +29,7 @@ interface DomainEvent
     public function getAggregateRootId(): string;
 
     /**
-     * The datetime the event occurred. Please use self::MICROSECOND_DATE_FORMAT format
+     * The datetime the event occurred. Please use self::MICROSECOND_DATE_FORMAT format.
      */
     public function getOccurredOn(): string;
 

--- a/src/Domain/Model/EventStore.php
+++ b/src/Domain/Model/EventStore.php
@@ -29,7 +29,7 @@ interface EventStore
      */
     public function allUnpublished(): array;
 
-    /**
+    /*
      * @param $eventId
      * @return StoredEvent[]|ArrayCollection
      */

--- a/src/Domain/Model/Traits/DomainEventTrait.php
+++ b/src/Domain/Model/Traits/DomainEventTrait.php
@@ -20,7 +20,7 @@ trait DomainEventTrait
     private $aggregateRootId;
 
     /**
-     * The datetime the event occurred. Please use DomainEvent::MICROSECOND_DATE_FORMAT format
+     * The datetime the event occurred. Please use DomainEvent::MICROSECOND_DATE_FORMAT format.
      *
      * @var string
      */
@@ -53,6 +53,6 @@ trait DomainEventTrait
 
     public function hasActorId(): bool
     {
-        return (bool)$this->actorId;
+        return (bool) $this->actorId;
     }
 }

--- a/src/EventSubscriber/PublishDomainEventSubscriber.php
+++ b/src/EventSubscriber/PublishDomainEventSubscriber.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Headsnet\DomainEventsBundle\EventSubscriber;
 
+use Headsnet\DomainEventsBundle\Domain\Model\DomainEvent;
 use Headsnet\DomainEventsBundle\Domain\Model\EventStore;
 use Headsnet\DomainEventsBundle\Domain\Model\StoredEvent;
 use Symfony\Component\Console\ConsoleEvents;
@@ -58,7 +59,7 @@ final class PublishDomainEventSubscriber implements EventSubscriberInterface
     }
 
     /**
-     * Support publishing events on TERMINATE event of both HttpKernel and Console
+     * Support publishing events on TERMINATE event of both HttpKernel and Console.
      *
      * @return string[]
      */
@@ -66,7 +67,7 @@ final class PublishDomainEventSubscriber implements EventSubscriberInterface
     {
         return [
             KernelEvents::TERMINATE => 'publishEventsFromHttp',
-            ConsoleEvents::TERMINATE => 'publishEventsFromConsole'
+            ConsoleEvents::TERMINATE => 'publishEventsFromConsole',
         ];
     }
 
@@ -99,6 +100,7 @@ final class PublishDomainEventSubscriber implements EventSubscriberInterface
                 $storedEvent->getTypeName(),
                 'json'
             );
+            assert($domainEvent instanceof DomainEvent);
 
             $this->eventBus->dispatch($domainEvent);
             $this->eventStore->publish($storedEvent);

--- a/src/HeadsnetDomainEventsBundle.php
+++ b/src/HeadsnetDomainEventsBundle.php
@@ -28,7 +28,7 @@ class HeadsnetDomainEventsBundle extends Bundle
         if (class_exists(DoctrineOrmMappingsPass::class)) {
             $container->addCompilerPass(
                 DoctrineOrmMappingsPass::createXmlMappingDriver(
-                    [realpath(__DIR__ . '/Doctrine/Mapping') => 'Headsnet\DomainEventsBundle\Domain\Model'],
+                    [realpath(__DIR__.'/Doctrine/Mapping') => 'Headsnet\DomainEventsBundle\Domain\Model'],
                     []
                 )
             );

--- a/tests/Functional/BundleInitializationTest.php
+++ b/tests/Functional/BundleInitializationTest.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of the Symfony HeadsnetDomainEventsBundle.
+ *
+ * (c) Headstrong Internet Services Ltd 2020
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Headsnet\DomainEventsBundle\Functional;
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use Headsnet\DomainEventsBundle\Doctrine\DoctrineEventStore;
+use Headsnet\DomainEventsBundle\Doctrine\EventSubscriber\PersistDomainEventSubscriber;
+use Headsnet\DomainEventsBundle\EventSubscriber\PublishDomainEventSubscriber;
+use Headsnet\DomainEventsBundle\HeadsnetDomainEventsBundle;
+use Nyholm\BundleTest\BaseBundleTestCase;
+use Nyholm\BundleTest\CompilerPass\PublicServicePass;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+
+class BundleInitializationTest extends BaseBundleTestCase
+{
+    protected function getBundleClass()
+    {
+        return HeadsnetDomainEventsBundle::class;
+    }
+
+    public function test_services_are_instantiated_ok(): void
+    {
+        $this->bootCustomKernel();
+        $container = $this->getContainer();
+
+        $services = [
+            'test.headsnet_domain_events.event_subscriber.publisher' => PublishDomainEventSubscriber::class,
+            'test.headsnet_domain_events.event_subscriber.persister' => PersistDomainEventSubscriber::class,
+            'test.headsnet_domain_events.repository.event_store_doctrine' => DoctrineEventStore::class,
+        ];
+
+        foreach ($services as $id => $class) {
+            $this->assertTrue($container->has($id));
+            $s = $container->get($id);
+            $this->assertInstanceOf($class, $s);
+        }
+    }
+
+    private function bootCustomKernel(): void
+    {
+        $kernel = $this->createKernel();
+
+        $kernel->addConfigFile(__DIR__.'/config.yml');
+
+        $this->addCompilerPass(new PublicServicePass('|headsnet_domain_events.*|'));
+
+        $kernel->addBundle(FrameworkBundle::class);
+        $kernel->addBundle(DoctrineBundle::class);
+
+        $this->bootKernel();
+    }
+}

--- a/tests/Functional/config.yml
+++ b/tests/Functional/config.yml
@@ -1,0 +1,45 @@
+
+doctrine:
+
+    dbal:
+        default_connection: default
+        connections:
+            default:
+                url: 'sqlite:///:memory:'
+                profiling: true
+                charset: UTF8
+
+    orm:
+        default_entity_manager: default
+        auto_generate_proxy_classes: true
+        naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
+        auto_mapping: true
+
+
+framework:
+
+    messenger:
+
+        default_bus: messenger.bus.event
+
+        buses:
+            messenger.bus.event:
+                default_middleware: allow_no_handlers
+
+    serializer: ~
+
+
+# Create test aliases for services, so they are not automatically removed from the container.
+services:
+
+    test.headsnet_domain_events.event_subscriber.publisher:
+        alias: headsnet_domain_events.event_subscriber.publisher
+        public: true
+
+    test.headsnet_domain_events.event_subscriber.persister:
+        alias: headsnet_domain_events.event_subscriber.persister
+        public: true
+
+    test.headsnet_domain_events.repository.event_store_doctrine:
+        alias: headsnet_domain_events.repository.event_store_doctrine
+        public: true

--- a/tests/Unit/Domain/Model/StoredEventTest.php
+++ b/tests/Unit/Domain/Model/StoredEventTest.php
@@ -1,0 +1,65 @@
+<?php
+/*
+ * This file is part of the Symfony HeadsnetDomainEventsBundle.
+ *
+ * (c) Headstrong Internet Services Ltd 2020
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Headsnet\DomainEventsBundle\Unit\Domain\Model;
+
+use Headsnet\DomainEventsBundle\Domain\Model\EventId;
+use Headsnet\DomainEventsBundle\Domain\Model\StoredEvent;
+use PHPUnit\Framework\TestCase;
+
+class StoredEventTest extends TestCase
+{
+    private const EVENT_ID = '2ffd5b4b-3f0f-48da-8a09-dd68b903b5f8';
+    private const ROOT_ID = '808621ef-8a0b-4c21-84e9-5ee3d7e186d5';
+    private const TYPE_NAME = 'Acme\\Namespace\\SomeClass';
+
+    public function test_event_id_getter_returns_correct_value(): void
+    {
+        $storedEvent = $this->buildStoredEvent();
+
+        $this->assertInstanceOf(EventId::class, $storedEvent->getEventId());
+        $this->assertEquals(self::EVENT_ID, $storedEvent->getEventId()->asString());
+    }
+
+    public function test_root_id_getter_returns_correct_value(): void
+    {
+        $storedEvent = $this->buildStoredEvent();
+
+        $this->assertEquals(self::ROOT_ID, $storedEvent->getAggregateRoot());
+    }
+
+    public function test_type_name_getter_returns_correct_value(): void
+    {
+        $storedEvent = $this->buildStoredEvent();
+
+        $this->assertEquals(self::TYPE_NAME, $storedEvent->getTypeName());
+    }
+
+    public function test_published_on_setter(): void
+    {
+        $storedEvent = $this->buildStoredEvent();
+
+        $publishedOn = new \DateTimeImmutable();
+        $storedEvent = $storedEvent->setPublishedOn($publishedOn);
+
+        $this->assertEquals($publishedOn, $storedEvent->getPublishedOn());
+    }
+
+    private function buildStoredEvent(): StoredEvent
+    {
+        return new StoredEvent(
+            EventId::fromString(self::EVENT_ID),
+            self::TYPE_NAME,
+            new \DateTimeImmutable(),
+            self::ROOT_ID,
+            ''
+        );
+    }
+}


### PR DESCRIPTION
Set up tests using the `symfony/phpunit-bridge` package.

Added a couple of basic tests. We are still missing the majority of the test coverage that we need.

Travis builds now test against supported PHP versions 7.2, 7.3 and 7.4, and also against Symfony 4 and Symfony 5.

Configured Phpstan for static analysis during CI build, plus fixed some violations it reported.

Added shortcuts to tests and static analysis to composer `scripts`, and added them to the README.