### PR TITLE
Dispatch an event before appending event to event store

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ event on to the `messenger.bus.event` event bus for consumption elsewhere.
 
 ### Amending domain events
 
-Even though events should be treated as immutable, it might be convinient
+Even though events should be treated as immutable, it might be convenient
 to add or change meta data before adding them to the event store.
 
 Before a domain event is appended to the event store,
@@ -92,7 +92,7 @@ the standard Doctrine event store emits a `PreAppendEvent` Symfony event,
 which can be used e.g. to set the actor ID as in the following example:
 
 ```php
-use App\IdentityAccess\Domain\Entity\User;
+use App\Entity\User;
 use Headsnet\DomainEventsBundle\Doctrine\Event\PreAppendEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Core\Security;

--- a/README.md
+++ b/README.md
@@ -82,6 +82,50 @@ class MyEntity implements ContainsEvents, RecordsEvents
 Then, in `kernel.TERMINATE` event, a listener automatically publishes the domain
 event on to the `messenger.bus.event` event bus for consumption elsewhere.
 
+### Amending domain events
+
+Even though events should be treated as immutable, it might be convinient
+to add or change meta data before adding them to the event store.
+
+Before a domain event is appended to the event store,
+the standard Doctrine event store emits a `PreAppendEvent` Symfony event,
+which can be used e.g. to set the actor ID as in the following example:
+
+```php
+use App\IdentityAccess\Domain\Entity\User;
+use Headsnet\DomainEventsBundle\Doctrine\Event\PreAppendEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\Security\Core\Security;
+
+final class AssignDomainEventUser implements EventSubscriberInterface
+{
+    private Security $security;
+
+    public function __construct(Security $security)
+    {
+        $this->security = $security;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            PreAppendEvent::class => 'onPreAppend'
+        ];
+    }
+
+    public function onPreAppend(PreAppendEvent $event): void
+    {
+        $domainEvent = $event->getDomainEvent();
+        if (null === $domainEvent->getActorId()) {
+            $user = $this->security->getUser();
+            if ($user instanceof User) {
+                $domainEvent->setActorId($user->getId());
+            }
+        }
+    }
+}
+```
+
 ### Deferring Events Into The Future
 
 If you specify a future date for the `DomainEvent::occurredOn` the event will

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
     "symfony/framework-bundle": "^4.4 || ^5.0",
     "symfony/lock": "^4.4 || ^5.0",
     "symfony/serializer": "^4.4 || ^5.0",
-    "symfony/messenger": "^4.4 || ^5.0"
+    "symfony/messenger": "^4.4 || ^5.0",
+    "symfony/event-dispatcher": "^4.4 || ^5.0"
   },
   "require-dev": {
     "symfony/phpunit-bridge": "^5.0",

--- a/src/Doctrine/Event/PreAppendEvent.php
+++ b/src/Doctrine/Event/PreAppendEvent.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headsnet\DomainEventsBundle\Doctrine\Event;
+
+use Headsnet\DomainEventsBundle\Domain\Model\DomainEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+/**
+ * Class PreAppendEvent.
+ *
+ * @author Wolfgang Klinger <wolfgang@wazum.com>
+ */
+class PreAppendEvent extends Event
+{
+    /**
+     * @var DomainEvent
+     */
+    protected $domainEvent;
+
+    public function __construct(DomainEvent $domainEvent)
+    {
+        $this->domainEvent = $domainEvent;
+    }
+
+    public function getDomainEvent(): DomainEvent
+    {
+        return $this->domainEvent;
+    }
+}

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -49,6 +49,7 @@
                  public="false">
             <argument type="service" id="doctrine.orm.default_entity_manager"/>
             <argument type="service" id="serializer"/>
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
     </services>


### PR DESCRIPTION
Resolves #19 

By dispatching an event before appending the domain event to the event store it's possible to amend the event data (e.g. set the actorId) loosely coupled.

Example usage:
```php
final class AssignDomainEventUser implements EventSubscriberInterface
{
    private Security $security;

    public function __construct(Security $security)
    {
        $this->security = $security;
    }

    public static function getSubscribedEvents(): array
    {
        return [
            PreAppendEvent::class => 'onPreAppend'
        ];
    }

    public function onPreAppend(PreAppendEvent $event): void
    {
        $domainEvent = $event->getDomainEvent();
        if (null === $domainEvent->getActorId()) {
            $user = $this->security->getUser();
            if ($user instanceof User) {
                $domainEvent->setActorId($user->getId());
            }
        }
    }
}

```