### PR TITLE
Alias the EventStore interface to the default event_store_doctrine service

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -51,6 +51,8 @@
             <argument type="service" id="serializer"/>
         </service>
 
+        <service id="Headsnet\DomainEventsBundle\Domain\Model\EventStore" alias="headsnet_domain_events.repository.event_store_doctrine"/>
+
     </services>
 
 </container>


### PR DESCRIPTION
Otherwise this leads to the following error when using the EventStore interface with dependency injection:

```
Cannot autowire service "App\MyApplication\Application\Service\SomeHandler": argument "$eventStore" of method "__construct()" references interface "Headsnet\DomainEventsBundle\Domain\Model\EventStore" but no such service exists. You should maybe alias this interface to the existing "headsnet_domain_events.repository.event_store_doctrine" service.
```
