### PR TITLE
Refresh StoredEvent object and confirm still unpublished

### DIFF
--- a/src/Doctrine/DoctrineEventStore.php
+++ b/src/Doctrine/DoctrineEventStore.php
@@ -103,14 +103,11 @@ final class DoctrineEventStore implements EventStore
      */
     public function allUnpublished(): array
     {
-        try
-        {
+        try {
             if (false === $this->em->getConnection()->createSchemaManager()->tablesExist([$this->tableName])) {
                 return []; // Connection does exist, but the events table does not exist.
             }
-        }
-        catch (ConnectionException $connectionException)
-        {
+        } catch (ConnectionException $connectionException) {
             return []; // Connection itself does not exist
         }
 
@@ -131,23 +128,8 @@ final class DoctrineEventStore implements EventStore
         return $qb->getQuery()->getResult();
     }
 
-    /*
-     * @return StoredEvent[]|ArrayCollection
-     */
-    /*public function allStoredEventsSince($eventId): ArrayCollection
+    public function refresh(StoredEvent $storedEvent): void
     {
-        $qb = $this->em->createQueryBuilder()
-            ->select('e')
-            ->from(StoredEvent::class, 'e')
-            ->orderBy('e.eventId');
-
-        if ($eventId)
-        {
-            $qb
-                ->where('se.eventId > :event_id')
-                ->setParameter('event_id', $eventId);
-        }
-
-        return $qb->getQuery()->getResult();
-    }*/
+        $this->em->refresh($storedEvent);
+    }
 }

--- a/src/Domain/Model/EventStore.php
+++ b/src/Domain/Model/EventStore.php
@@ -12,8 +12,6 @@ declare(strict_types=1);
 
 namespace Headsnet\DomainEventsBundle\Domain\Model;
 
-use Doctrine\Common\Collections\ArrayCollection;
-
 interface EventStore
 {
     public function nextIdentity(): EventId;
@@ -22,16 +20,12 @@ interface EventStore
 
     public function replace(DomainEvent $domainEvent): void;
 
-    public function publish(StoredEvent $domainEvent): void;
+    public function publish(StoredEvent $storedEvent): void;
 
     /**
      * @return StoredEvent[]
      */
     public function allUnpublished(): array;
 
-    /*
-     * @param $eventId
-     * @return StoredEvent[]|ArrayCollection
-     */
-    //public function allStoredEventsSince($eventId): ArrayCollection;
+    public function refresh(StoredEvent $storedEvent): void;
 }

--- a/src/Domain/Model/StoredEvent.php
+++ b/src/Domain/Model/StoredEvent.php
@@ -25,7 +25,7 @@ class StoredEvent
     private $occurredOn;
 
     /**
-     * @var \DateTimeImmutable
+     * @var \DateTimeImmutable|null
      */
     private $publishedOn;
 
@@ -68,7 +68,7 @@ class StoredEvent
         return $this->occurredOn;
     }
 
-    public function getPublishedOn(): \DateTimeImmutable
+    public function getPublishedOn(): ?\DateTimeImmutable
     {
         return $this->publishedOn;
     }


### PR DESCRIPTION
In extremely high concurrency situations, it was possible for the entities loaded in `PublishDomainEventSubscriber::publishEvents()` to be published by another process, before the subsequent lock was acquired.

This commit enables a Doctrine "refresh" of the entity, inside the lock, which then allows us to perform a reliable lookup of the entity's published status, and then only publish if it is still unpublished.