### PR TITLE
Add recordsOnce() method

### DIFF
--- a/src/Doctrine/Event/PreAppendEvent.php
+++ b/src/Doctrine/Event/PreAppendEvent.php
@@ -14,10 +14,7 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 class PreAppendEvent extends Event
 {
-    /**
-     * @var DomainEvent
-     */
-    protected $domainEvent;
+    protected DomainEvent $domainEvent;
 
     public function __construct(DomainEvent $domainEvent)
     {

--- a/src/Domain/Model/EventId.php
+++ b/src/Domain/Model/EventId.php
@@ -17,10 +17,7 @@ use Ramsey\Uuid\UuidInterface;
 
 final class EventId
 {
-    /**
-     * @var UuidInterface
-     */
-    private $id;
+    private UuidInterface $id;
 
     private function __construct(UuidInterface $id)
     {

--- a/src/Domain/Model/RecordsEvents.php
+++ b/src/Domain/Model/RecordsEvents.php
@@ -15,4 +15,6 @@ namespace Headsnet\DomainEventsBundle\Domain\Model;
 interface RecordsEvents
 {
     public function record(DomainEvent $event): void;
+
+    public function recordOnce(DomainEvent $event): void;
 }

--- a/src/Domain/Model/StoredEvent.php
+++ b/src/Domain/Model/StoredEvent.php
@@ -14,35 +14,17 @@ namespace Headsnet\DomainEventsBundle\Domain\Model;
 
 class StoredEvent
 {
-    /**
-     * @var string
-     */
-    private $eventId;
+    private string $eventId;
 
-    /**
-     * @var \DateTimeImmutable
-     */
-    private $occurredOn;
+    private \DateTimeImmutable $occurredOn;
 
-    /**
-     * @var \DateTimeImmutable|null
-     */
-    private $publishedOn;
+    private \DateTimeImmutable|null $publishedOn;
 
-    /**
-     * @var string
-     */
-    private $aggregateRoot;
+    private string $aggregateRoot;
 
-    /**
-     * @var string
-     */
-    private $typeName;
+    private string $typeName;
 
-    /**
-     * @var string
-     */
-    private $eventBody;
+    private string $eventBody;
 
     public function __construct(
         EventId $eventId,

--- a/src/Domain/Model/Traits/DomainEventTrait.php
+++ b/src/Domain/Model/Traits/DomainEventTrait.php
@@ -14,22 +14,14 @@ namespace Headsnet\DomainEventsBundle\Domain\Model\Traits;
 
 trait DomainEventTrait
 {
-    /**
-     * @var string
-     */
-    private $aggregateRootId;
+    private string $aggregateRootId;
 
     /**
      * The datetime the event occurred. Please use DomainEvent::MICROSECOND_DATE_FORMAT format.
-     *
-     * @var string
      */
-    private $occurredOn;
+    private string $occurredOn;
 
-    /**
-     * @var string|null
-     */
-    private $actorId;
+    private string|null $actorId;
 
     public function setActorId(?string $actorId): void
     {

--- a/src/Domain/Model/Traits/EventRecorderTrait.php
+++ b/src/Domain/Model/Traits/EventRecorderTrait.php
@@ -38,4 +38,13 @@ trait EventRecorderTrait
     {
         $this->messages[] = $message;
     }
+
+    public function recordOnce(DomainEvent $message): void
+    {
+        if (in_array($message, $this->messages, true)) {
+            return;
+        }
+
+        $this->messages[] = $message;
+    }
 }

--- a/src/Domain/Model/Traits/EventRecorderTrait.php
+++ b/src/Domain/Model/Traits/EventRecorderTrait.php
@@ -19,7 +19,7 @@ trait EventRecorderTrait
     /**
      * @var DomainEvent[]
      */
-    private $messages = [];
+    private array $messages = [];
 
     /**
      * @return DomainEvent[]

--- a/src/EventSubscriber/NoEnvelopeDomainEventDispatcher.php
+++ b/src/EventSubscriber/NoEnvelopeDomainEventDispatcher.php
@@ -17,10 +17,7 @@ use Symfony\Component\Messenger\MessageBusInterface;
 
 class NoEnvelopeDomainEventDispatcher implements DomainEventDispatcher
 {
-    /**
-     * @var MessageBusInterface
-     */
-    private $eventBus;
+    private MessageBusInterface $eventBus;
 
     public function __construct(MessageBusInterface $eventBus)
     {

--- a/src/EventSubscriber/PublishDomainEventSubscriber.php
+++ b/src/EventSubscriber/PublishDomainEventSubscriber.php
@@ -25,25 +25,13 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 final class PublishDomainEventSubscriber implements EventSubscriberInterface
 {
-    /**
-     * @var DomainEventDispatcher
-     */
-    private $domainEventDispatcher;
+    private DomainEventDispatcher $domainEventDispatcher;
 
-    /**
-     * @var EventStore
-     */
-    private $eventStore;
+    private EventStore $eventStore;
 
-    /**
-     * @var SerializerInterface
-     */
-    private $serializer;
+    private SerializerInterface $serializer;
 
-    /**
-     * @var LockFactory
-     */
-    private $lockFactory;
+    private LockFactory $lockFactory;
 
     public function __construct(
         DomainEventDispatcher $domainEventDispatcher,

--- a/tests/Unit/Domain/Model/EventRecorderTest.php
+++ b/tests/Unit/Domain/Model/EventRecorderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Headsnet\DomainEventsBundle\Unit\Domain\Model;
+
+use Headsnet\DomainEventsBundle\Domain\Model\ContainsEvents;
+use Headsnet\DomainEventsBundle\Domain\Model\DomainEvent;
+use Headsnet\DomainEventsBundle\Domain\Model\RecordsEvents;
+use Headsnet\DomainEventsBundle\Domain\Model\Traits\DomainEventTrait;
+use Headsnet\DomainEventsBundle\Domain\Model\Traits\EventRecorderTrait;
+use PHPUnit\Framework\TestCase;
+
+class EventRecorderTest extends TestCase
+{
+    public function test_event_is_recorded(): void
+    {
+        $sut = $this->fakeAggregate();
+        $event = $this->fakeEvent();
+
+        $sut->record($event);
+
+        $this->assertCount(1, $sut->getRecordedEvents());
+        $this->assertSame($event, $sut->getRecordedEvents()[0]);
+    }
+
+    public function test_multiple_duplicate_events_are_all_recorded(): void
+    {
+        $sut = $this->fakeAggregate();
+        $event = $this->fakeEvent();
+
+        $sut->record($event);
+        $sut->record($event);
+
+        $this->assertCount(2, $sut->getRecordedEvents());
+        $this->assertSame($event, $sut->getRecordedEvents()[0]);
+        $this->assertSame($event, $sut->getRecordedEvents()[1]);
+    }
+
+    public function test_record_once_ignores_duplicate_event(): void
+    {
+        $sut = $this->fakeAggregate();
+        $event = $this->fakeEvent();
+
+        $sut->recordOnce($event);
+        $sut->recordOnce($event);
+
+        $this->assertCount(1, $sut->getRecordedEvents());
+        $this->assertSame($event, $sut->getRecordedEvents()[0]);
+    }
+
+    public function test_multiple_events_are_recorded_once_each(): void
+    {
+        $sut = $this->fakeAggregate();
+        $event1 = $this->fakeEvent();
+        $event2 = $this->fakeEvent();
+
+        $sut->recordOnce($event1);
+        $sut->recordOnce($event1); // This duplicate should be ignored
+        $sut->recordOnce($event2);
+        $sut->recordOnce($event2); // This duplicate should be ignored
+
+        $this->assertCount(2, $sut->getRecordedEvents());
+        $this->assertSame($event1, $sut->getRecordedEvents()[0]);
+        $this->assertSame($event2, $sut->getRecordedEvents()[1]);
+    }
+
+    /**
+     * @return RecordsEvents&ContainsEvents
+     */
+    public function fakeAggregate(): object
+    {
+        return new class() implements RecordsEvents, ContainsEvents {
+            use EventRecorderTrait;
+        };
+    }
+
+    public function fakeEvent(): DomainEvent
+    {
+        return new class() implements DomainEvent {
+            use DomainEventTrait;
+        };
+    }
+}


### PR DESCRIPTION
Add a "recordOnce" method that will prevent duplicate event objects (i.e. that meet strict comparison) from being added.