### PR TITLE
Update README.md with correct Symfony version constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ These events are then published using a Symfony event listener in the
 This ensures transactional consistency and guaranteed delivery via the Outbox
 pattern.
 
-_Requires Symfony 4.4 or higher_
+_Requires Symfony 5.4 or higher._
 
 ### Installation
 


### PR DESCRIPTION
composer.json states
```json
  "require": {
    "php": "^8.1",
    "doctrine/orm": "^2.5 || ^3.0",
    "doctrine/doctrine-bundle": "^2.0",
    "ramsey/uuid-doctrine": "^1.5 || ^2.0",
    "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.0",
    "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.0",
    "symfony/lock": "^5.4 || ^6.4 || ^7.0",
    "symfony/messenger": "^5.4 || ^6.4 || ^7.0",
    "symfony/property-access": "^5.4 || ^6.4 || ^7.0",
    "symfony/serializer": "^5.4 || ^6.4 || ^7.0"
  },
```
so this should be Symfony 5.4 instead of 4.4, right?