### PR TITLE
Use canonical `PostgreSQLPlatform` class name (DBAL 4)

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,4 +16,3 @@ parameters:
     ignoreErrors:
         -
           identifier: missingType.generics
-        - '#Class Doctrine\\DBAL\\Platforms\\PostgreSqlPlatform not found#'

--- a/src/Doctrine/DBAL/Types/DateTimeImmutableMicrosecondsType.php
+++ b/src/Doctrine/DBAL/Types/DateTimeImmutableMicrosecondsType.php
@@ -14,7 +14,7 @@ namespace Headsnet\DomainEventsBundle\Doctrine\DBAL\Types;
 
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Platforms\MySQLPlatform;
-use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\VarDateTimeImmutableType;
 
@@ -40,9 +40,9 @@ class DateTimeImmutableMicrosecondsType extends VarDateTimeImmutableType
     public function convertToDatabaseValue($value, AbstractPlatform $platform): ?string
     {
         if ($value instanceof \DateTimeImmutable &&
-            ($platform instanceof PostgreSqlPlatform || $platform instanceof MySQLPlatform)
+            ($platform instanceof PostgreSQLPlatform || $platform instanceof MySQLPlatform)
         ) {
-            $dateTimeFormat = $platform->getDateTimeFormatString(); // @phpstan-ignore-line
+            $dateTimeFormat = $platform->getDateTimeFormatString();
 
             return $value->format("{$dateTimeFormat}.u");
         }


### PR DESCRIPTION
Closes #48

`DateTimeImmutableMicrosecondsType` referenced `Doctrine\DBAL\Platforms\PostgreSqlPlatform`, which was removed in DBAL 4. At runtime it still matched, because PHP resolves class names case-insensitively and the platform object is already loaded, but that is also why `phpstan.neon` needed the `#Class ...PostgreSqlPlatform not found#` ignore.

This switches to the canonical `PostgreSQLPlatform`, which exists in both DBAL 3 and 4, and removes the now-unnecessary PHPStan ignore. Behaviour is unchanged; the existing microsecond round-trip assertion in `DomainEventPersistenceTest` continues to cover MySQL/PostgreSQL.

No dependency constraints are changed, so this stays green across the full PHP / Symfony / Doctrine matrix.