### PR TITLE
Fix CI: replace EOL Symfony 7.2 with 7.4, pin static analysis jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,10 @@ jobs:
             matrix:
                 operating-system: [ ubuntu-latest, windows-latest ]
                 php: ['8.1', '8.2', '8.3', '8.4']
-                symfony: ['5.4.*', '6.4.*', '7.2.*']
+                symfony: ['5.4.*', '6.4.*', '7.4.*']
                 doctrine: ['^2.5', '^3.0']
                 exclude:
-                    - { php: '8.1', symfony: '7.2.*' }
+                    - { php: '8.1', symfony: '7.4.*' }
                     - { php: '8.1', doctrine: '^3.0' }
                     - { symfony: '5.4.*', doctrine: '^3.0' }
 
@@ -58,10 +58,10 @@ jobs:
             fail-fast: false
             matrix:
                 php: ['8.1', '8.2', '8.3', '8.4']
-                symfony: ['5.4.*', '6.4.*', '7.2.*']
+                symfony: ['5.4.*', '6.4.*', '7.4.*']
                 doctrine: ['^2.5', '^3.0']
                 exclude:
-                    - { php: '8.1', symfony: '7.2.*' }
+                    - { php: '8.1', symfony: '7.4.*' }
                     - { php: '8.1', doctrine: '^3.0' }
                     - { symfony: '5.4.*', doctrine: '^3.0' }
 
@@ -102,10 +102,10 @@ jobs:
             fail-fast: false
             matrix:
                 php: ['8.1', '8.2', '8.3', '8.4']
-                symfony: ['5.4.*', '6.4.*', '7.2.*']
+                symfony: ['5.4.*', '6.4.*', '7.4.*']
                 doctrine: ['^2.5', '^3.0']
                 exclude:
-                    - { php: '8.1', symfony: '7.2.*' }
+                    - { php: '8.1', symfony: '7.4.*' }
                     - { php: '8.1', doctrine: '^3.0' }
                     - { symfony: '5.4.*', doctrine: '^3.0' }
 
@@ -134,8 +134,11 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: latest
+                  tools: flex
                   coverage: none
             - uses: ramsey/composer-install@v3
+              env:
+                  SYMFONY_REQUIRE: 7.4.*
             - run: vendor/bin/ecs
 
     phpstan:
@@ -146,6 +149,9 @@ jobs:
             - uses: shivammathur/setup-php@v2
               with:
                   php-version: latest
+                  tools: flex
                   coverage: none
             - uses: ramsey/composer-install@v3
+              env:
+                  SYMFONY_REQUIRE: 7.4.*
             - run: vendor/bin/phpstan

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,8 +21,6 @@ class Configuration implements ConfigurationInterface
     {
         $treeBuilder = new TreeBuilder('headsnet_domain_events');
 
-        // @see https://github.com/phpstan/phpstan/issues/844
-        // @phpstan-ignore-next-line
         $treeBuilder->getRootNode()
             ->children()
                 ->arrayNode('message_bus')


### PR DESCRIPTION
Closes #50

CI is currently red on `main`. Two independent, dependency-driven problems:

**1. Symfony 7.2 is EOL and blocked by a security advisory.**
Every `7.2.*` job fails at `composer install`. `symfony/cache` 7.x is affected by CVE-2026-45073 (SQL injection in `PdoAdapter::doClear()`), which Composer 2.10 blocks by default. The only patched 7.x release is 7.4.12, and 7.2 is end of life, so there is no installable `symfony/cache` for the `7.2.*` column. This moves the matrix to `7.4.*` (maintained LTS, patched). `composer.json` already allows it via `^7.0`, so no constraint change.

**2. The `ecs` and `phpstan` jobs install an incoherent Symfony mix.**
With no Symfony pin they resolve 7.4 core components alongside 8.1 `http-foundation` / `var-exporter`, which breaks ORM proxy generation and makes PHPStan report `Request`/`Response` as not found. Pinning both jobs to a coherent Symfony via `flex` + `SYMFONY_REQUIRE` fixes this, matching the PHPUnit jobs.

**3. Obsolete PHPStan ignore.**
`Configuration.php` carried a `@phpstan-ignore-next-line` for phpstan#844. On current dependencies no error is reported there, so the ignore is unmatched and fails the run. Removed.

Verified locally (DDEV, PHP 8.4, Symfony 7.4, Doctrine ORM 3.6 / DBAL 4.4): PHPUnit (14 tests), PHPStan and ECS all green.