### PR TITLE
Replace deprecated `Criteria::ASC` with string literal

### DIFF
--- a/src/Console/EventNameCheckCommand.php
+++ b/src/Console/EventNameCheckCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Headsnet\DomainEventsBundle\Console;
 
-use Doctrine\Common\Collections\Criteria;
 use Doctrine\ORM\EntityManagerInterface;
 use Headsnet\DomainEventsBundle\Domain\Model\StoredEvent;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -103,7 +102,7 @@ final class EventNameCheckCommand extends Command
             ])
             ->from(StoredEvent::class, 'event')
             ->groupBy('event.typeName')
-            ->orderBy('event.typeName', Criteria::ASC)
+            ->orderBy('event.typeName', 'ASC')
             ->getQuery()
             ->getResult();
 


### PR DESCRIPTION
Closes #52

`EventNameCheckCommand` ordered results with `Criteria::ASC`, which is `@deprecated` in doctrine/collections 2.x (superseded by the `Order` enum) and will be removed in a future major.

The call is an ORM `QueryBuilder::orderBy()`, which takes a plain string direction, so this uses the literal `'ASC'` and drops the now-unused `Doctrine\Common\Collections\Criteria` import. No behaviour change.

Verified locally (DDEV, PHP 8.4, Symfony 7.4, Doctrine ORM 3.6 / DBAL 4.4): PHPUnit, PHPStan and ECS all green.